### PR TITLE
Fixed user show page when there is not itineraries for user

### DIFF
--- a/app/javascript/plugins/init_mapbox.js
+++ b/app/javascript/plugins/init_mapbox.js
@@ -102,22 +102,28 @@ const initMapbox = () => {
         container: cont,
         style: 'mapbox://styles/rubixthecubix/ckpa6hfqu6ejy18oj9bz9d98a',
       });
-      let transportProfile = "walking";
-      const start = [markers[0].lng, markers[0].lat];
-      const lastItemIndex = markers.length - 1
       if (cont == "user-map"){
         if(markers.length == 0 ){
           markers = JSON.parse(mapElement.dataset.allMarkers);
           addMarkers(map, markers);
           fitMapToMarkers(map, markers);
         } else {
+          let transportProfile = "walking";
+          const start = [markers[0].lng, markers[0].lat];
+          const lastItemIndex = markers.length - 1
           generateRoutePath(map, markers, transportProfile, lastItemIndex, start);
           toggleMarkers(map, mapElement,transportProfile, lastItemIndex, start); // keep this in if if we revert back
         }
       } else if (cont == 'itinerary-map'){
+        let transportProfile = "walking";
+        const start = [markers[0].lng, markers[0].lat];
+        const lastItemIndex = markers.length - 1
         generateRoutePath(map, markers, transportProfile, lastItemIndex, start);
       }
       else {
+        let transportProfile = "walking";
+        const start = [markers[0].lng, markers[0].lat];
+        const lastItemIndex = markers.length - 1
         addMarkers(map, markers);
         fitMapToMarkers(map, markers);
       }


### PR DESCRIPTION
When there wasn't any itineraries for the user the map was breaking as it could find the itineraries longitude and latitude for the markers. Add lat and lon within the if statement if the markers exists. 
<img width="527" alt="Screenshot 2021-06-21 at 15 41 44" src="https://user-images.githubusercontent.com/53355525/122782107-5b1e8e80-d2a8-11eb-9a59-c9113a1ab510.png">
<img width="843" alt="Screenshot 2021-06-21 at 15 48 49" src="https://user-images.githubusercontent.com/53355525/122782092-578b0780-d2a8-11eb-892a-f4a9a7a17c51.png">
<img width="1136" alt="Screenshot 2021-06-21 at 15 48 44" src="https://user-images.githubusercontent.com/53355525/122782098-58bc3480-d2a8-11eb-8b81-580bdace1564.png">
<img width="1072" alt="Screenshot 2021-06-21 at 15 48 56" src="https://user-images.githubusercontent.com/53355525/122782077-535eea00-d2a8-11eb-8ad8-e5cede7cf2f2.png">
<img width="1054" alt="Screenshot 2021-06-21 at 15 49 06" src="https://user-images.githubusercontent.com/53355525/122782109-5bb72500-d2a8-11eb-83a6-c8dc42bbd9ff.png">
