### PR TITLE
Stamps index background fix

### DIFF
--- a/app/assets/stylesheets/components/_single_stampbook.scss
+++ b/app/assets/stylesheets/components/_single_stampbook.scss
@@ -35,6 +35,16 @@
   width:100vw;
 }
 
+.index-stamps-box {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-image:linear-gradient(to bottom, rgba(#0f000c, 0.8), rgba(#030000, 0.6), rgba(#030000, 0.4)), url('https://res.cloudinary.com/laicuroot/image/upload/v1623347607/stampbook_background_qv4nx8.png');
+  background-size: cover;
+  background-attachment: fixed;
+  width:100vw;
+}
+
 .stamps-header {
   display: flex;
   position: relative;

--- a/app/assets/stylesheets/components/_single_stampbook.scss
+++ b/app/assets/stylesheets/components/_single_stampbook.scss
@@ -42,6 +42,8 @@
   background-image:linear-gradient(to bottom, rgba(#0f000c, 0.8), rgba(#030000, 0.6), rgba(#030000, 0.4)), url('https://res.cloudinary.com/laicuroot/image/upload/v1623347607/stampbook_background_qv4nx8.png');
   background-size: cover;
   background-attachment: fixed;
+  overflow: hidden;
+  height: 100vh;
   width:100vw;
 }
 
@@ -256,3 +258,34 @@
   91.67% { transform: translate(-50px, 50px) rotate(300deg); }
   100% { transform: translate(0, 0) rotate(360deg); }
 }
+
+
+@media(min-width: 1440px){
+  .index-stamps-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-image:linear-gradient(to bottom, rgba(#0f000c, 0.8), rgba(#030000, 0.6), rgba(#030000, 0.4)), url('https://res.cloudinary.com/laicuroot/image/upload/v1623347607/stampbook_background_qv4nx8.png');
+    background-size: cover;
+    background-repeat: no-repeat;
+    overflow: hidden;
+    background-attachment: fixed;
+    width:100vw;
+    height: 100%;
+  }
+}
+
+@media(min-width: 1441px){
+  .index-stamps-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow: hidden;
+    background-image:linear-gradient(to bottom, rgba(#0f000c, 0.8), rgba(#030000, 0.6), rgba(#030000, 0.4)), url('https://res.cloudinary.com/laicuroot/image/upload/v1623347607/stampbook_background_qv4nx8.png');
+    background-size: cover;
+    background-attachment: fixed;
+    width:100vw;
+    height: 100vh;
+  }
+}
+

--- a/app/views/stamps/index.html.erb
+++ b/app/views/stamps/index.html.erb
@@ -1,4 +1,4 @@
-<div class="stamps-box">
+<div class="index-stamps-box">
   <div class='d-flex justify-content-between w-100 mt-5'>
     <div class="stampbook-owner ml-3">
        <% if @stampbook.user.photo.attached? %>


### PR DESCRIPTION

https://user-images.githubusercontent.com/53355525/122897928-58707780-d342-11eb-8df3-c66e17662782.mov

Fixed issue in the Stamps index where in small screens you couldn't scroll down. I have added 2 media queries for bigger screens, change the height depending on the screen and fixed the overflow. I have given the container it's own class in case we have issues in other screens, but it should work fine everywhere. 

